### PR TITLE
Rename Smol to Fruitful and port to Reef Pelagia testnet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Fruitful (fruitful.sponsian.org) — a suite of small crypto dapps (send, disperse, swap, revoke, multisafe, address-book, wallet) built with Next.js App Router, React 19, TypeScript, wagmi/viem, RainbowKit, and Tailwind CSS. Bun is the package manager (`bun.lockb`).
+
+Fruitful is a fork of Smol (SmolDapp), rebranded and ported to the **Reef Pelagia testnet** (chain ID 13939, native REEF with 12 decimals, PolkaVM via `pallet-revive`). Ethereum mainnet is also kept (ENS/Clusters resolution; swap and multisafe only work there). Internal identifiers still use the Smol naming (`Smol*` components, `TSmol*` types, `SMOL_*` env vars) — only user-visible branding was renamed. See `docs/pelagia-port-plan.md` and `docs/pelagia-contract-deployment.md`.
+
+## Commands
+
+- `bun install` — install dependencies
+- `bun run dev` — start Next.js dev server
+- `bun run dev:ts` — TypeScript compiler in watch mode (run alongside dev)
+- `bun run build` — production build (`next build --webpack`)
+- `bun run lint` — ESLint over `.js,.jsx,.ts,.tsx`
+- `bun run prettier-format` — format with Prettier
+- `tsc --noEmit` — typecheck. **Important:** `next.config.js` sets `typescript.ignoreBuildErrors: true`, so the build will NOT catch type errors — run tsc explicitly.
+
+There is no test suite.
+
+Running the app locally requires RPC env vars (`RPC_URI_FOR_<chainId>`) and `WALLETCONNECT_PROJECT_ID`; see the `env` block in `next.config.js` for the full list. API routes use `TELEGRAM_BOT`/`TELEGRAM_CHAT` (notify/report endpoints) and degrade if unset.
+
+## Architecture
+
+Everything lives in `app/` (Next.js App Router):
+
+- `app/(apps)/<name>/` — one folder per mini-app (send, disperse, swap, revoke, multisafe, address-book, wallet). Each is self-contained: `page.tsx`, `components/`, `contexts/` (the app's state provider, e.g. `useSend.tsx`, `useDisperse.tsx`, `useSwapFlow.lifi.tsx`), `types.ts`, and app-specific utils/actions. The swap app is powered by LiFi (`swap/utils/api.lifi.ts`).
+- Shared code lives in underscore-prefixed dirs imported via the `@lib/*` path aliases (defined in `tsconfig.json`):
+  - `@lib/utils/*` → `app/_utils/*` — chain config, address/erc20/transaction helpers, ABIs
+  - `@lib/components/*` → `app/_components/*` — shared UI (Smol* inputs, curtains, modals)
+  - `@lib/icons/*` → `app/_components/icons/*`
+  - `@lib/contexts/*` → `app/_contexts/*` — global providers
+  - `@lib/hooks/*` → `app/_hooks/*` — generic hooks plus `web3/` (ENS, Clusters, validation, Safe detection)
+- `app/api/notify` and `app/api/report` — API routes that forward messages/screenshots to Telegram.
+
+### Provider stack
+
+`app/layout.tsx` hydrates wagmi state from cookies (SSR) and wraps everything in `app/Providers.tsx`:
+`WithFonts → IndexedDB → WithMom → WalletContextApp → WithPopularTokens → WithPrices → SafeProvider → PlausibleProvider`
+
+- `WithMom` (`app/_contexts/WithMom.tsx`) owns the wagmi/RainbowKit/react-query config and builds per-chain RPC transports (`withRPC`) from env vars with fallbacks. The wagmi `config` is exported from here.
+- `useWallet` provides connected-account balances; `WithPrices` provides token prices; token lists come from SmolDapp/tokenLists.
+
+### Chain configuration
+
+`app/_utils/tools.chains.ts` is the single source of truth for supported networks (currently Ethereum mainnet + Reef Pelagia). `CHAINS` is a record keyed by chain id where each entry extends a viem `Chain` with app metadata (`isEnabledInProd`, `isLifiSwapSupported`, `isMultisafeSupported`, `safeAPIURI`, `disperseAddress`, etc.). It exports `networks` and `supportedNetworks`. Add/modify chain support here, plus the matching `RPC_URI_FOR_<id>` env entry in `next.config.js`. Testnet chains flagged `isEnabledInProd` (Reef Pelagia) are treated as user-facing networks; `useWallet` skips other testnets outside dev. The Pelagia entry's `disperseAddress`/`contracts.multicall3` are placeholders until the contracts are deployed (see `docs/pelagia-contract-deployment.md`); the disperse button stays disabled while `disperseAddress` is the zero address.
+
+## Code style (enforced by ESLint/Prettier; lint-staged runs prettier + eslint --fix + tsc on commit)
+
+- Tabs, single quotes, semicolons, 120-char lines, no trailing commas.
+- Type aliases must be PascalCase prefixed with `T` (`TAddress`), interfaces with `I`; prefer `type` over `interface`.
+- Boolean variables must be prefixed (`is`, `should`, `has`, `can`, ...).
+- Explicit function return types are required (`ReactElement` for components).
+- Type-only imports must use `import type`, and types go last in import order (builtin → external → internal → relative → types).
+- JSX props and children require curly braces: `<Button label={'text'}>{'children'}</Button>`.
+- `useAsyncTrigger` (in `@lib/hooks`) is checked by `react-hooks/exhaustive-deps` like a built-in hook.

--- a/README.md
+++ b/README.md
@@ -1,129 +1,69 @@
-# Smoldapp
+# Fruitful
 
-![https://raw.githubusercontent.com/SmolDapp/SmolV2/main/public/og.png](https://raw.githubusercontent.com/SmolDapp/SmolV2/main/public/og.png)
+> Simple, smart and elegant dapps, designed to make your crypto journey a little bit easier — running on the [Reef Pelagia](https://docs.reef.io/docs/developers/pelagia/) testnet.
 
-> The safest way to transfer all your ERC20 tokens at once!
+Fruitful is a suite of small crypto dapps (a fork of [Smol](https://github.com/SmolDapp/smoldapp), rebranded and ported to Reef Pelagia):
 
-Migratooor is an easy and secure way to move all your Ethereum and ERC20 tokens from one wallet to another, with a single signature if using gnosis. This process does not involve any smart contracts!
+- **send** — transfer native REEF and ERC-20 tokens
+- **disperse** — send tokens to many addresses in one transaction
+- **revoke** — review and revoke ERC-20 allowances
+- **address-book** — local, private address book (IndexedDB)
+- **wallet** — token balances overview
+- **swap** — cross-chain swaps via LiFi (Ethereum mainnet only; LiFi does not support Pelagia)
+- **multisafe** — Safe deployment across chains (Ethereum mainnet only; Safe contracts do not exist on PolkaVM)
 
-## Why Use Migratooor?
+Live at <https://fruitful.sponsian.org>.
 
--   **Secure:** You don't need to trust any third-party smart contract! For maximum security, you can run the source code yourself and avoid any phishing risks!
--   **Easy to Use:** Our user-friendly interface allows you to quickly select all the tokens you want to migrate!
+## Networks
 
-Migratooor employs the [ethers](https://docs.ethers.org/v5/) library to transfer ERC20 tokens from one wallet to another. This generates all the transactions needed to securely move your tokens to the wallet of your choosing!
+| Network | Chain ID | Notes |
+| --- | --- | --- |
+| Reef Pelagia | 13939 | Primary target. REEF native token with **12 decimals**. PolkaVM via `pallet-revive`. |
+| Ethereum mainnet | 1 | Kept for ENS/Clusters name resolution and for the swap/multisafe apps. |
 
-## How To Use Migratooor
+Network support is defined in `app/_utils/tools.chains.ts`. The Disperse and Multicall3 contracts must be deployed on Pelagia and their addresses recorded there — see [docs/pelagia-contract-deployment.md](docs/pelagia-contract-deployment.md). The port plan lives in [docs/pelagia-port-plan.md](docs/pelagia-port-plan.md).
 
-Using Migratooor is simple. Here's a quick step-by-step guide to transferring tokens with Migratooor:
+## Develop
 
-1. **Connect your wallet** to get started
-2. **Select the tokens** you want to transfer
-3. **Input the amount** of tokens you want to transfer
-4. **Enter the address** of the wallet you want to transfer the tokens to
-5. **Confirm the transactions** and wait for them to be processed by the Ethereum network
-6. **Transfer complete!** All tokens have been sent to the recipient's wallet
-
-
-## Configuring
-
-In order to run migratooor, you need to set up the environment variables for the JSON-RPC URLs of the Ethereum networks you want to support. You also need to set up the receiver address and disperse address. These settings can be found in the `next.config.js` file:
-
-```javascript
-env: {
-    JSON_RPC_URL: {
-        1: process.env.RPC_URL_MAINNET,
-        10: process.env.RPC_URL_OPTIMISM,
-        250: process.env.RPC_URL_FANTOM,
-        42161: process.env.RPC_URL_ARBITRUM
-    },
-    RECEIVER_ADDRESS: '0x10001192576E8079f12d6695b0948C2F41320040',
-    DISPERSE_ADDRESS: '0xD152f549545093347A162Dce210e7293f1452150'
-}
-```
-
-You can set these environment variables in a `.env` file in the project root directory. Make sure to replace the values with the appropriate URLs and addresses for your project.
-
-Here's an example of a `.env` file:
-
-```
-RPC_URL_MAINNET=https://mainnet.infura.io/v3/YOUR_API_KEY
-RPC_URL_OPTIMISM=https://optimism.infura.io/v3/YOUR_API_KEY
-RPC_URL_FANTOM=https://fantom.infura.io/v3/YOUR_API_KEY
-RPC_URL_ARBITRUM=https://arbitrum.infura.io/v3/YOUR_API_KEY
-RECEIVER_ADDRESS=0x10001192576E8079f12d6695b0948C2F41320040
-DISPERSE_ADDRESS=0xD152f549545093347A162Dce210e7293f1452150
-```
-
-Replace `YOUR_API_KEY` with your own Infura API key or any other Ethereum JSON-RPC provider. Make sure to use the correct receiver and disperse addresses for your project.
-
-Once you've set up the environment variables, you're ready to run the project using the commands outlined in the previous sections.
-
-## Build and Develop
-
-### Prerequisites
-
-Before you proceed, make sure you have the following installed on your machine:
-
-- [Node.js](https://nodejs.org/)
-- [npm](https://www.npmjs.com/) (comes bundled with Node.js)
-
-### Installing Dependencies
-
-First, navigate to migratooor root directory in your terminal and run the following command to install all the required dependencies:
+Prerequisites: [Bun](https://bun.sh).
 
 ```bash
-npm install
+bun install
+bun run dev      # Next.js dev server
+bun run dev:ts   # TypeScript watch mode (run alongside dev)
 ```
 
-### Development Mode
-
-To run migratooor in development mode, use the following command:
+The build does **not** fail on type errors (`ignoreBuildErrors` is set) — run `tsc --noEmit` to typecheck.
 
 ```bash
-npm run dev
+bun run build            # production build
+bun run lint             # ESLint
+bun run prettier-format  # Prettier
 ```
 
-If you want to run the TypeScript compiler in watch mode alongside the development server, use:
+## Configuration
+
+Set environment variables in a `.env` file at the project root:
 
 ```bash
-npm run dev:ts
+# RPC endpoints (the Pelagia default hostname is auto-generated and may rotate —
+# always set it explicitly in production; current value at
+# https://docs.reef.io/docs/developers/networks/)
+RPC_URI_FOR_1=https://eth.llamarpc.com
+RPC_URI_FOR_13939=https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io
+
+# WalletConnect (required for wallet connections)
+WALLETCONNECT_PROJECT_ID=your_project_id
+
+# Optional: Telegram notifications for the /api/notify and /api/report routes
+TELEGRAM_BOT=
+TELEGRAM_CHAT=
 ```
 
-### Building the Project
+## Getting testnet REEF
 
-To build migratooor, run the following command:
+Use the [Pelagia faucet](https://docs.reef.io/docs/developers/pelagia-faucet/) — paste your `0x…` address and you'll receive 2,000 REEF within ~30 seconds. Testnet REEF has no real value.
 
-```bash
-npm run build
-```
+## License
 
-This command will first compile the TypeScript files and then build the project using the `next` command.
-
-## Starting the Production Server
-
-To start the production server, first build migratooor (if you haven't already), and then run the following command:
-
-```bash
-npm run start
-```
-
-### Exporting the Project
-
-To export migratooor for deployment to IPFS, run the following command:
-
-```bash
-npm run export
-```
-
-This command will first compile the TypeScript files, then build migratooor using the `next` command, and finally export the build to the `ipfs` folder.
-
-### Linting
-
-To run the ESLint linter, use the following command:
-
-```bash
-npm run lint
-```
-
-This command will check all `.js`, `.jsx`, `.ts`, and `.tsx` files in the project for linting issues.
+MIT — see [LICENSE](LICENSE). Forked from [SmolDapp/smoldapp](https://github.com/SmolDapp/smoldapp).

--- a/app/(apps)/_appHeading/index.tsx
+++ b/app/(apps)/_appHeading/index.tsx
@@ -66,7 +66,7 @@ export default function AppHeading(): ReactElement {
 
 		return {
 			title: 'Nothing here!',
-			description: 'We can’t find the page you’re looking for. But here’s a smol mouse!'
+			description: 'We can’t find the page you’re looking for. But here’s a small mouse!'
 		};
 	}, [pathName]);
 

--- a/app/(apps)/_appInfo/AddressBookAppInfo.tsx
+++ b/app/(apps)/_appInfo/AddressBookAppInfo.tsx
@@ -5,14 +5,14 @@ function AddressBookAppInfo(): ReactElement {
 		<>
 			<p>
 				{
-					'The Smol address book was designed to make your life easier, but more importantly, protect you from common '
+					'The Fruitful address book was designed to make your life easier, but more importantly, protect you from common '
 				}
 				{'address mimicking scams.'}{' '}
 			</p>
 			<br />
 			<p>{'Addresses are saved locally on your browser so no one but you ever sees them! '}</p>
 			<br />
-			<p>{'“Wow, privacy and functionality, you Smol guys rock!” '}</p>
+			<p>{'“Wow, privacy and functionality, you Fruitful guys rock!” '}</p>
 			<br />
 			<p>{'Thanks anon, now go forth and send thy digital tokens.'}</p>
 		</>

--- a/app/(apps)/_appInfo/MultisafeAppInfo.tsx
+++ b/app/(apps)/_appInfo/MultisafeAppInfo.tsx
@@ -10,7 +10,7 @@ const FAQ = [
 	},
 	{
 		question: 'What is MultiSafe?',
-		answer: 'MultiSafe is an application developed by Smol that allows users to create and deploy Safe smart contract wallets across multiple blockchain networks using a single address.'
+		answer: 'MultiSafe is an application developed by Fruitful that allows users to create and deploy Safe smart contract wallets across multiple blockchain networks using a single address.'
 	},
 	{
 		question: 'How do I create a Safe?',
@@ -63,7 +63,7 @@ function MultisafeAppInfo(): ReactElement {
 					}
 				</p>
 				<p className={'text-sm'}>
-					{'Smol charges a smol fee of $4.20 per deployment, for more info - check out the FAQ below.'}
+					{'Fruitful charges a small fee of $4.20 per deployment, for more info - check out the FAQ below.'}
 				</p>
 			</div>
 			<div className={'my-4 h-px w-full bg-neutral-300'} />

--- a/app/(apps)/_appInfo/RevokeAppInfo.tsx
+++ b/app/(apps)/_appInfo/RevokeAppInfo.tsx
@@ -22,7 +22,7 @@ function RevokeAppInfo(): ReactElement {
 			</p>
 			<br />
 			<p>
-				{'Smol Revoke is using '}
+				{'Fruitful Revoke is using '}
 				<a
 					href={'https://github.com/RevokeCash/whois/'}
 					className={'text-neutral-900 underline'}>

--- a/app/(apps)/_appInfo/SwapAppInfo.tsx
+++ b/app/(apps)/_appInfo/SwapAppInfo.tsx
@@ -60,7 +60,7 @@ function SwapAppInfo(): ReactElement {
 			</div>
 			<div>
 				<div className={'mb-4 h-px w-full bg-neutral-300'} />
-				<p className={'text-sm text-neutral-900'}>{'Smol Swap is powered by Li.Fi'}</p>
+				<p className={'text-sm text-neutral-900'}>{'Fruitful Swap is powered by Li.Fi'}</p>
 				<p className={'text-sm'}>
 					{'It allows you to swap tokens on the same chain, or across different chains. '}
 				</p>
@@ -68,7 +68,7 @@ function SwapAppInfo(): ReactElement {
 					{'You can even use it like a bridge by swapping to the same token on your destination chain. '}
 				</p>
 				<br />
-				<p className={'text-sm text-neutral-900'}>{'Using Smol Swap is simple.'}</p>
+				<p className={'text-sm text-neutral-900'}>{'Using Fruitful Swap is simple.'}</p>
 				<div className={'mt-2'}>
 					<p className={'text-sm font-medium'}>{'Step 1:'}</p>
 					<p className={'pl-4 text-sm'}>{'Select the network you want to swap tokens from.'}</p>
@@ -95,12 +95,12 @@ function SwapAppInfo(): ReactElement {
 				<p className={'text-sm text-neutral-900'}>{'Amount to receive!'}</p>
 				<p className={'text-sm'}>
 					{
-						"Smol swap displays the EXPECTED amount of tokens you'll receive. So you might end up with a bit more or a bit fewer tokens - this depends on your slippage settings."
+						"Fruitful swap displays the EXPECTED amount of tokens you'll receive. So you might end up with a bit more or a bit fewer tokens - this depends on your slippage settings."
 					}
 				</p>
 				<br />
 				<p className={'text-sm text-neutral-900'}>{'We have a fee'}</p>
-				<p className={'text-sm'}>{'Smol charges a 0.3% fee on swaps to fund starving devs. Ty'}</p>
+				<p className={'text-sm'}>{'Fruitful charges a 0.3% fee on swaps to fund starving devs. Ty'}</p>
 			</div>
 		</div>
 	);

--- a/app/(apps)/disperse/components/Wizard.tsx
+++ b/app/(apps)/disperse/components/Wizard.tsx
@@ -463,7 +463,12 @@ export function DisperseWizard(): ReactElement {
 			</span>
 			<Button
 				isBusy={disperseStatus.pending || approvalStatus.pending}
-				isDisabled={isAboveBalance || configuration.inputs.length === 0 || !isValid}
+				isDisabled={
+					isAboveBalance ||
+					configuration.inputs.length === 0 ||
+					!isValid ||
+					(!shouldUseSend && isZeroAddress(CHAINS[chainID].disperseAddress))
+				}
 				onClick={(): void | Promise<void> => {
 					if (shouldUseSend) {
 						return onSendSingleToken();

--- a/app/(apps)/page.tsx
+++ b/app/(apps)/page.tsx
@@ -2,13 +2,8 @@
 
 import {Alignment, Fit, Layout, useRive} from '@rive-app/react-canvas';
 import Link from 'next/link';
-import {
-	IconAppAddressBook,
-	IconAppDisperse,
-	IconAppRevoke,
-	IconAppStream,
-	IconAppSwap
-} from '@lib/components/icons/IconApps';
+
+import {IconAppAddressBook, IconAppDisperse, IconAppRevoke, IconAppSwap} from '@lib/components/icons/IconApps';
 import IconMultisafe from '@lib/icons/IconMultisafe';
 import {cl} from '@lib/utils/helpers';
 
@@ -59,7 +54,7 @@ export default function Page(): ReactElement {
 					</h1>
 					<p className={'mt-6 w-full text-sm text-[#060B11] md:mb-10 md:w-11/12 md:text-base'}>
 						{
-							'Smol adds super powers to your wallet, to make your crypto journey faster, simpler and maybe even a little bit sexier.'
+							'Fruitful adds super powers to your wallet, to make your crypto journey faster, simpler and maybe even a little bit sexier.'
 						}
 					</p>
 
@@ -106,7 +101,7 @@ export default function Page(): ReactElement {
 							{'AND BRIDGE'}
 						</span>
 					}
-					description={'Enjoy crosschain swaps lightening fast with Smol Swap'}
+					description={'Enjoy crosschain swaps lightening fast with Fruitful Swap'}
 					link={'/swap'}
 					buttonTitle={'Make a swap'}
 					icon={<IconAppSwap className={'size-4'} />}
@@ -124,19 +119,6 @@ export default function Page(): ReactElement {
 					link={'/disperse'}
 					buttonTitle={'Disperse tokens'}
 					icon={<IconAppDisperse className={'size-4'} />}
-				/>
-				<Cutaway
-					title={
-						<span>
-							{'CLAIM YOUR'}
-							<br />
-							{'STREAM'}
-						</span>
-					}
-					description={"Whether it's a salary, a grant or something else, Smol will help you claim it."}
-					link={'https://v1.smold.app/stream'}
-					buttonTitle={'Claim your stream'}
-					icon={<IconAppStream className={'size-4'} />}
 				/>
 				<Cutaway
 					title={

--- a/app/(apps)/pixel/pages.tsx
+++ b/app/(apps)/pixel/pages.tsx
@@ -9,12 +9,7 @@ type TMessageEvent = {
 	key: string;
 };
 
-const ALLOWED_ORIGIN = [
-	'http://localhost:3000',
-	'https://app.safe.global',
-	'https://playground.smold.app',
-	'https://mylittlestable.mom'
-];
+const ALLOWED_ORIGIN = ['http://localhost:3000', 'https://app.safe.global', 'https://fruitful.sponsian.org'];
 
 function PixelPage(): ReactElement {
 	const {getAll} = useIndexedDBStore<TAddressBookEntry>('address-book');

--- a/app/(apps)/swap/components/SettingsCurtain.tsx
+++ b/app/(apps)/swap/components/SettingsCurtain.tsx
@@ -3,6 +3,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import Link from 'next/link';
 import {usePlausible} from 'next-plausible';
+
 import {CurtainContent, CurtainTitle} from '@lib/components/Curtain';
 import {CloseCurtainButton} from '@lib/components/Curtains/InfoCurtain';
 import {cl} from '@lib/utils/helpers';
@@ -51,7 +52,7 @@ export function SwapCurtain(props: TSwapCurtain): ReactElement {
 									<p className={'text-sm text-neutral-900'}>{'Route preference'}</p>
 									<p className={'text-xs text-neutral-600'}>
 										{
-											'Smol’s cross chain swaps are powered by Li.Fi. Smol priotizes the safest swap route by default but you can change your settings here. To learn more about the different options please feel free to check Li.Fi’s '
+											'Fruitful’s cross chain swaps are powered by Li.Fi. Fruitful priotizes the safest swap route by default but you can change your settings here. To learn more about the different options please feel free to check Li.Fi’s '
 										}
 										<Link
 											target={'_blank'}

--- a/app/(apps)/swap/utils/api.lifi.ts
+++ b/app/(apps)/swap/utils/api.lifi.ts
@@ -81,8 +81,9 @@ export async function getLifiRoutes(params: {
 				toAddress: params.toAddress,
 				slippage: params.slippage,
 				order: params.order,
-				//Smol configuration
-				integrator: 'Smol',
+				//Fruitful configuration — the integrator string and referrer must be registered
+				//with Li.Fi for the fee share to be collected
+				integrator: 'Fruitful',
 				fee: 0.003,
 				referrer: toAddress(process.env.SMOL_ADDRESS_V2)
 			}

--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -33,7 +33,7 @@ function Providers(props: {children: ReactNode; initialState: State | undefined}
 							<WithPrices supportedNetworks={supportedNetworks}>
 								<SafeProvider>
 									<PlausibleProvider
-										domain={process.env.PLAUSIBLE_DOMAIN || 'smold.app'}
+										domain={process.env.PLAUSIBLE_DOMAIN || 'fruitful.sponsian.org'}
 										enabled={true}>
 										{props.children}
 									</PlausibleProvider>

--- a/app/_components/SideMenu/SideMenuNav/index.tsx
+++ b/app/_components/SideMenu/SideMenuNav/index.tsx
@@ -203,16 +203,9 @@ export function SideMenuNav(props: {menu?: TSideMenuItem[]; onClose?: () => void
 								<Link
 									onClick={() => plausible(PLAUSIBLE_EVENTS.NAVIGATE_TO_GITHUB)}
 									className={'transition-colors hover:text-neutral-900'}
-									href={'https://github.com/SmolDapp'}
+									href={'https://github.com/sponsian/Fruitful'}
 									target={'_blank'}>
 									{'GitHub'}
-								</Link>
-								<Link
-									onClick={() => plausible(PLAUSIBLE_EVENTS.NAVIGATE_TO_TWITTER)}
-									className={'transition-colors hover:text-neutral-900'}
-									href={'https://twitter.com/smoldapp'}
-									target={'_blank'}>
-									{'Twitter'}
 								</Link>
 							</div>
 							<LogOutButton />

--- a/app/_components/SuccessModal.tsx
+++ b/app/_components/SuccessModal.tsx
@@ -27,7 +27,7 @@ function SuccessModal(props: TSuccessModal): ReactElement {
 
 	const tweetURL = useMemo(() => {
 		if (props.twitterShareContent) {
-			return `http://twitter.com/share?text=${props.twitterShareContent}&url=https://smold.app`;
+			return `http://twitter.com/share?text=${props.twitterShareContent}&url=https://fruitful.sponsian.org`;
 		}
 		return '';
 	}, [props.twitterShareContent]);

--- a/app/_contexts/useAddressBook.tsx
+++ b/app/_contexts/useAddressBook.tsx
@@ -59,17 +59,17 @@ export const WithAddressBook = ({children}: {children: React.ReactElement}): Rea
 	const chainID = useChainId();
 
 	useMountEffect(async () => {
-		/* Initially add smol address in the AB */
+		/* Initially add the team address in the AB */
 		const entriesFromDB = await getAll();
 		if (entriesFromDB.length === 0) {
 			add({
 				address: toAddress(process.env.SMOL_ADDRESS),
-				label: 'smol',
+				label: 'fruitful',
 				isFavorite: false,
 				chains: supportedNetworks.map(chain => chain.id),
 				isHidden: false,
 				numberOfInteractions: 0,
-				slugifiedLabel: 'smol'
+				slugifiedLabel: 'fruitful'
 			});
 			setEntryNonce(nonce => nonce + 1);
 		}

--- a/app/_contexts/useWallet.tsx
+++ b/app/_contexts/useWallet.tsx
@@ -9,6 +9,7 @@ import {toTToken, toTokenListToken, useTokenList} from '@lib/contexts/WithTokenL
 import {useAsyncTrigger} from '@lib/hooks/useAsyncTrigger';
 import {zeroNormalizedBN} from '@lib/utils/numbers';
 import {ethTokenAddress, isZeroAddress, toAddress} from '@lib/utils/tools.addresses';
+import {CHAINS} from '@lib/utils/tools.chains';
 import {DEFAULT_ERC20} from '@lib/utils/tools.erc20';
 import {createUniqueID} from '@lib/utils/tools.identifiers';
 
@@ -100,7 +101,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
 		}
 
 		for (const chain of config.chains) {
-			if (chain.testnet && !props.shouldWorkOnTestnet) {
+			if (chain.testnet && !CHAINS[chain.id]?.isEnabledInProd && !props.shouldWorkOnTestnet) {
 				continue;
 			}
 			if (chain.id === 1337 && !props.shouldWorkOnTestnet) {

--- a/app/_utils/tools.chains.ts
+++ b/app/_utils/tools.chains.ts
@@ -2,39 +2,7 @@
 'use client';
 
 import {zeroAddress} from 'viem';
-import {
-	arbitrum,
-	aurora,
-	avalanche,
-	base,
-	baseSepolia,
-	berachain,
-	blast,
-	bsc,
-	celo,
-	confluxESpace,
-	fantom,
-	filecoin,
-	flare,
-	fraxtal,
-	gnosis,
-	ink,
-	katana,
-	linea,
-	mainnet,
-	mantle,
-	metis,
-	mode,
-	optimism,
-	polygon,
-	polygonZkEvm,
-	scroll,
-	sepolia,
-	sonic,
-	unichain,
-	zksync,
-	zora
-} from 'viem/chains';
+import {mainnet} from 'viem/chains';
 
 import {toAddress} from '@lib/utils/tools.addresses';
 
@@ -44,6 +12,7 @@ import type {Chain} from 'viem';
 type TSmolChains = Record<
 	number,
 	Chain & {
+		isEnabledInProd: boolean;
 		isLifiSwapSupported: boolean;
 		isMultisafeSupported: boolean;
 		safeAPIURI: string;
@@ -98,6 +67,37 @@ function assignRPCUrls(chain: Chain, rpcUrls?: string[]): TAssignRPCUrls {
 	};
 }
 
+/**************************************************************************************************
+ ** Reef Pelagia is the next-generation Reef testnet, running PolkaVM via pallet-revive. It is
+ ** EVM-compatible at the RPC layer, but no canonical Ethereum contract (Multicall3, Disperse,
+ ** Safe) exists at its usual address — everything must be deployed fresh with resolc. See
+ ** docs/pelagia-contract-deployment.md for the deployment procedure.
+ ** The RPC and explorer hostnames are auto-generated cluster names and may rotate: always prefer
+ ** the env-injected RPC_URI_FOR_13939 and re-check https://docs.reef.io/docs/developers/networks/
+ ** if the defaults stop responding.
+ ** Note: REEF has 12 decimals on Pelagia (and on mainnet once this upgrade goes live), not 18.
+ *************************************************************************************************/
+const reefPelagia = {
+	id: 13939,
+	name: 'Reef Pelagia',
+	nativeCurrency: {
+		decimals: 12,
+		name: 'Reef',
+		symbol: 'REEF'
+	},
+	rpcUrls: {
+		default: {http: ['https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io']},
+		public: {http: ['https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io']}
+	},
+	blockExplorers: {
+		default: {
+			name: 'Blockscout',
+			url: 'https://explorer-frontend-ibcy8d-1204c4-72-60-35-83.nip.io'
+		}
+	},
+	testnet: true
+} as const satisfies Chain;
+
 const localhost = {
 	id: 1337,
 	name: 'Localhost',
@@ -127,8 +127,13 @@ const localhost = {
 
 const isDev = process.env.NODE_ENV === 'development' && Boolean(process.env.SHOULD_USE_FORKNET);
 const CHAINS: TSmolChains = {
+	/**********************************************************************************************
+	 ** Mainnet stays in the config because ENS and Clusters name resolution are pinned to chain 1
+	 ** (see app/_hooks/web3/useENS.ts). It remains fully usable as a network in its own right.
+	 ********************************************************************************************/
 	[mainnet.id]: {
 		...mainnet,
+		isEnabledInProd: true,
 		isLifiSwapSupported: true,
 		isMultisafeSupported: true,
 		safeAPIURI: 'https://safe-transaction-mainnet.safe.global',
@@ -139,359 +144,31 @@ const CHAINS: TSmolChains = {
 		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
 		rpcUrls: assignRPCUrls(mainnet)
 	},
-	[optimism.id]: {
-		...optimism,
-		name: 'Optimism',
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-optimism.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=oeth:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'optimism',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
-		rpcUrls: assignRPCUrls(optimism)
-	},
-	[bsc.id]: {
-		...bsc,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-bsc.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=bnb:',
-		coingeckoGasCoinID: 'binancecoin',
-		llamaChainName: 'bsc',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(bsc)
-	},
-	[gnosis.id]: {
-		...gnosis,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-gnosis-chain.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=gno:',
-		coingeckoGasCoinID: 'xdai',
-		llamaChainName: 'xdai',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
-		rpcUrls: assignRPCUrls(gnosis)
-	},
-	[polygon.id]: {
-		...polygon,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-polygon.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=matic:',
-		coingeckoGasCoinID: 'matic-network',
-		llamaChainName: 'polygon',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
-		rpcUrls: assignRPCUrls(polygon)
-	},
-	[polygonZkEvm.id]: {
-		...polygonZkEvm,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-zkevm.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=zkevm:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(polygonZkEvm)
-	},
-	[fantom.id]: {
-		...fantom,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.fantom.network/home?safe=ftm:',
-		coingeckoGasCoinID: 'fantom',
-		llamaChainName: 'fantom',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(fantom)
-	},
-	[zksync.id]: {
-		...zksync,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-zksync.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=zksync:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(zksync)
-	},
-	[mantle.id]: {
-		...mantle,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://multisig.mantle.xyz/home?safe=mantle:',
-		coingeckoGasCoinID: 'mantle',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(mantle)
-	},
-	[base.id]: {
-		...base,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-base.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=base:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'base',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
-		rpcUrls: assignRPCUrls(base)
-	},
-	[sepolia.id]: {
-		...sepolia,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-sepolia.safe.global',
-		safeUIURI: 'https://app.safe.global/apps?safe=sep:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(sepolia)
-	},
-	[baseSepolia.id]: {
-		...baseSepolia,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-base-sepolia.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=basesep:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(baseSepolia)
-	},
-	[arbitrum.id]: {
-		...arbitrum,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-arbitrum.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=arb1:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'arbitrum',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: toAddress('0x1112dbcf805682e828606f74ab717abf4b4fd8de'),
-		rpcUrls: assignRPCUrls(arbitrum)
-	},
-	[celo.id]: {
-		...celo,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-celo.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=celo:',
-		coingeckoGasCoinID: 'celo',
-		llamaChainName: 'celo',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(celo)
-	},
-	[avalanche.id]: {
-		...avalanche,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-avalanche.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=avax:',
-		coingeckoGasCoinID: 'avalanche-2',
-		llamaChainName: 'avax',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(avalanche)
-	},
-	[linea.id]: {
-		...linea,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.linea.build/home?safe=linea:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xe025e5B1c61FD98e33F02caC811469664A81b4BD'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(linea)
-	},
-	[scroll.id]: {
-		...scroll,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://app.safe.global/home?safe=scr:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'scroll',
-		disperseAddress: toAddress('0x38a9C84bAaf727F8E09deF72C4Dc224fEFf2028F'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(scroll)
-	},
-	[metis.id]: {
-		...metis,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: false,
-		safeAPIURI: '',
-		safeUIURI: 'https://metissafe.tech/home?safe=metis-andromeda:',
-		coingeckoGasCoinID: 'metis-token',
-		disperseAddress: toAddress('0x8137aba86f91c8E592d6A791e06D0C868DBad3C8'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(metis)
-	},
-	[aurora.id]: {
-		...aurora,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-aurora.safe.global',
-		safeUIURI: 'https://app.safe.global/home?safe=aurora:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xe025e5B1c61FD98e33F02caC811469664A81b4BD'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(aurora)
-	},
-	[zora.id]: {
-		...zora,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.optimism.io/home?safe=zora:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xF7D540b9d4b94a24389802Bcf2f6f02013d08142'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(zora)
-	},
-	[mode.id]: {
-		...mode,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.optimism.io/home?safe=mode:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(mode)
-	},
-	[fraxtal.id]: {
-		...fraxtal,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.mainnet.frax.com/home?safe=fraxtal:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0xC813978A4c104250B1d2bC198cC7bE74b68Cd81b'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(fraxtal)
-	},
-	[confluxESpace.id]: {
-		...confluxESpace,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: false,
-		safeAPIURI: '',
-		safeUIURI: 'https://safe.conflux123.xyz/home?safe=CFX:',
-		coingeckoGasCoinID: 'conflux-token',
-		disperseAddress: toAddress('0x8137aba86f91c8e592d6a791e06d0c868dbad3c8'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(confluxESpace)
-	},
-	[blast.id]: {
-		...blast,
-		isLifiSwapSupported: true,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://blast-safe.io/home?safe=blast:',
-		coingeckoGasCoinID: 'ethereum',
-		disperseAddress: toAddress('0x274889F6864Bc0493BfEe3CF292A2A0ba1A76951'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(blast)
-	},
-	[filecoin.id]: {
-		...filecoin,
+	/**********************************************************************************************
+	 ** Reef Pelagia: no LiFi route support, no Safe contracts on PolkaVM, no DefiLlama price
+	 ** coverage (llamaChainName stays unset so price lookups skip this chain).
+	 ** disperseAddress is the zero address until the Disperse contract is deployed — follow
+	 ** docs/pelagia-contract-deployment.md, then fill in disperseAddress and contracts.multicall3
+	 ** below. Until multicall3 is set, balance reads on Pelagia will fail and be skipped.
+	 ********************************************************************************************/
+	[reefPelagia.id]: {
+		...reefPelagia,
+		isEnabledInProd: true,
 		isLifiSwapSupported: false,
 		isMultisafeSupported: false,
 		safeAPIURI: '',
 		safeUIURI: '',
-		coingeckoGasCoinID: 'filecoin',
-		llamaChainName: 'filecoin',
-		disperseAddress: toAddress('0xD152f549545093347A162Dce210e7293f1452150'),
+		coingeckoGasCoinID: 'reef',
+		disperseAddress: zeroAddress,
 		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(filecoin)
-	},
-	[berachain.id]: {
-		...berachain,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-berachain.safe.global',
-		safeUIURI: 'https://safe.berachain.com/home?safe=berachain:',
-		coingeckoGasCoinID: 'berachain-bera',
-		llamaChainName: 'bera',
-		disperseAddress: toAddress('0x9c981Fa0FfF6dE9AC193FE4224e499445C814Bc4'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(berachain)
-	},
-	[unichain.id]: {
-		...unichain,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-unichain.safe.global/',
-		safeUIURI: 'https://app.safe.global/home?safe=uni:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'ethereum',
-		disperseAddress: toAddress('0xd15fE25eD0Dba12fE05e7029C88b10C25e8880E3'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(unichain)
-	},
-	[ink.id]: {
-		...ink,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: 'https://safe-transaction-ink.safe.global/',
-		safeUIURI: 'https://app.safe.global/home?safe=ink:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'ethereum',
-		disperseAddress: toAddress('0x0000000000000000000000000000000000000000'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(ink)
-	},
-	[flare.id]: {
-		...flare,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://multisig.flare.network/home?safe=flare:',
-		coingeckoGasCoinID: 'flare-networks',
-		llamaChainName: 'flare',
-		disperseAddress: toAddress('0xd15fE25eD0Dba12fE05e7029C88b10C25e8880E3'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(flare)
-	},
-	[sonic.id]: {
-		...sonic,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://app.safe.global/home?safe=sonic:',
-		coingeckoGasCoinID: 'sonic-3',
-		llamaChainName: 'sonic-3',
-		disperseAddress: toAddress('0xd15fE25eD0Dba12fE05e7029C88b10C25e8880E3'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(sonic)
-	},
-	[katana.id]: {
-		...katana,
-		isLifiSwapSupported: false,
-		isMultisafeSupported: true,
-		safeAPIURI: '',
-		safeUIURI: 'https://app.safe.global/home?safe=katana:',
-		coingeckoGasCoinID: 'ethereum',
-		llamaChainName: 'ethereum',
-		disperseAddress: toAddress('0xd15fE25eD0Dba12fE05e7029C88b10C25e8880E3'),
-		yearnRouterAddress: undefined,
-		rpcUrls: assignRPCUrls(katana)
+		rpcUrls: assignRPCUrls(reefPelagia)
 	}
 };
 
 if (isDev) {
 	CHAINS[localhost.id] = {
 		...localhost,
+		isEnabledInProd: false,
 		isLifiSwapSupported: true,
 		isMultisafeSupported: true,
 		safeUIURI: 'https://app.safe.global/home?safe=eth:',
@@ -503,8 +180,12 @@ if (isDev) {
 	};
 }
 
-const supportedNetworks: Chain[] = Object.values(CHAINS).filter(e => !e.testnet);
-const supportedTestNetworks: Chain[] = Object.values(CHAINS).filter(e => e.testnet);
+/**************************************************************************************************
+ ** supportedNetworks is the user-facing list (network selector, address book, send/swap status).
+ ** A testnet chain flagged isEnabledInProd (Reef Pelagia) belongs there alongside mainnet.
+ *************************************************************************************************/
+const supportedNetworks: Chain[] = Object.values(CHAINS).filter(e => !e.testnet || e.isEnabledInProd);
+const supportedTestNetworks: Chain[] = Object.values(CHAINS).filter(e => e.testnet && !e.isEnabledInProd);
 const networks: Chain[] = [...supportedNetworks, ...supportedTestNetworks];
 
 export {CHAINS, networks, supportedNetworks};

--- a/app/_utils/twitter.ts
+++ b/app/_utils/twitter.ts
@@ -1,6 +1,6 @@
 export const TWEETER_SHARE_CONTENT = {
-	SWAP: 'I%20just%20swapped%20on%20Smold.app%2C%20the%20homepage%20for%20your%20crypto%20adventure.%20Maybe%20you%E2%80%99ll%20see%20this%20tweet%20and%20use%20Smol%20too%3F%20Wouldn%E2%80%99t%20that%20be%20nice%21',
-	SEND: 'I%20just%20sent%20tokens%20on%20Smold.app%2C%20the%20easiest%20way%20to%20send%20crypto%20around.%20Facts%21%20If%20you%20like%20sending%20stuff%2C%20maybe%20you%20should%20check%20it%20out%21',
+	SWAP: 'I%20just%20swapped%20on%20Fruitful%2C%20the%20homepage%20for%20your%20crypto%20adventure.%20Maybe%20you%E2%80%99ll%20see%20this%20tweet%20and%20use%20Fruitful%20too%3F%20Wouldn%E2%80%99t%20that%20be%20nice%21',
+	SEND: 'I%20just%20sent%20tokens%20on%20Fruitful%2C%20the%20easiest%20way%20to%20send%20crypto%20around.%20Facts%21%20If%20you%20like%20sending%20stuff%2C%20maybe%20you%20should%20check%20it%20out%21',
 	DISPERSE:
-		'I%20just%20used%20disperse%20on%20Smold.app%2C%20the%20easiest%20way%20to%20send%20tokens%20to%20muliple%20addresses%20in%20a%20single%20transaction.%20Fancy%21%20If%20you%20read%20this%20tweet%20you%20definitely%20shouldn%27t%20check%20out%20Smold.app.%20%28Reverse%20psychology%20innit%29.'
+		'I%20just%20used%20disperse%20on%20Fruitful%2C%20the%20easiest%20way%20to%20send%20tokens%20to%20muliple%20addresses%20in%20a%20single%20transaction.%20Fancy%21%20If%20you%20read%20this%20tweet%20you%20definitely%20shouldn%27t%20check%20out%20Fruitful.%20%28Reverse%20psychology%20innit%29.'
 };

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,10 +2,10 @@
 import type {MetadataRoute} from 'next';
 
 const siteConfig = {
-	name: 'Smol Dapp',
+	name: 'Fruitful',
 	description: 'Simple, smart and elegant dapps, designed to make your crypto journey a little bit easier.',
-	url: 'https://smold.app',
-	ogImage: 'https://smold.app/og.png'
+	url: 'https://fruitful.sponsian.org',
+	ogImage: 'https://fruitful.sponsian.org/og.png'
 };
 
 export default function manifest(): MetadataRoute.Manifest {

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,8 +1,8 @@
 import type {Metadata} from 'next';
 
 export const metadata: Metadata = {
-	title: 'SmolV2',
-	description: 'SmolV2 Application',
+	title: 'Fruitful',
+	description: 'Fruitful Application',
 	manifest: '/manifest.json',
 	icons: {
 		icon: [
@@ -16,6 +16,6 @@ export const metadata: Metadata = {
 	appleWebApp: {
 		capable: true,
 		statusBarStyle: 'default',
-		title: 'SmolV2'
+		title: 'Fruitful'
 	}
 };

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -31,15 +31,15 @@ export default function NotFoundPage(): ReactElement {
 }
 
 NotFoundPage.AppName = 'Nothing here!';
-NotFoundPage.AppDescription = 'We can’t find the page you’re looking for. But here’s a smol mouse!';
+NotFoundPage.AppDescription = 'We can’t find the page you’re looking for. But here’s a small mouse!';
 
 /**************************************************************************************************
  ** Metadata for the page: 404
  *************************************************************************************************/
-NotFoundPage.MetadataTitle = 'Smol - Built by MOM';
+NotFoundPage.MetadataTitle = 'Fruitful';
 NotFoundPage.MetadataDescription =
 	'Simple, smart and elegant dapps, designed to make your crypto journey a little bit easier.';
-NotFoundPage.MetadataURI = 'https://smold.app';
-NotFoundPage.MetadataOG = 'https://smold.app/og.png';
+NotFoundPage.MetadataURI = 'https://fruitful.sponsian.org';
+NotFoundPage.MetadataOG = 'https://fruitful.sponsian.org/og.png';
 NotFoundPage.MetadataTitleColor = '#000000';
 NotFoundPage.MetadataThemeColor = '#FFD915';

--- a/docs/pelagia-contract-deployment.md
+++ b/docs/pelagia-contract-deployment.md
@@ -1,0 +1,199 @@
+# Deploying Fruitful's contracts on Reef Pelagia testnet
+
+Step-by-step guide for deploying the two contracts Fruitful needs on Reef Pelagia: **Multicall3** (batched balance reads) and **Disperse** (the disperse app). No other contracts are required — send, revoke, wallet, and address-book use only these plus standard ERC-20 calls.
+
+> **Why this isn't a normal EVM deployment.** Pelagia executes contracts on **PolkaVM via `pallet-revive`**, not the standard EVM. Contracts must be Solidity ≥ 0.8.0 and compiled with **`resolc`** (not `solc`). The `@parity/hardhat-polkadot` plugin handles this. Canonical addresses you know from other chains (Multicall3 at `0xcA11…ca11`, Disperse at `0xD152…2150`) do **not** exist here and cannot be reproduced — you deploy fresh and record your own addresses.
+
+## 1. Prerequisites
+
+- Node.js 20+ and npm (or bun)
+- MetaMask (or any EVM wallet that supports custom networks)
+- A **fresh, testnet-only private key**. Never reuse a key that holds real funds.
+
+## 2. Add Reef Pelagia to your wallet
+
+MetaMask → network selector → "Add a custom network":
+
+| Field | Value |
+| --- | --- |
+| Network name | Reef Pelagia |
+| RPC URL | `https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/` |
+| Chain ID | `13939` |
+| Currency symbol | `REEF` |
+| Block explorer | `https://explorer-frontend-ibcy8d-1204c4-72-60-35-83.nip.io/` |
+
+> The RPC/explorer hostnames are auto-generated and may rotate. If they fail, get the current ones from <https://docs.reef.io/docs/developers/networks/>.
+
+## 3. Fund the deployer from the faucet
+
+1. Open `https://faucet.reef-node-reefdevcluster-6058af-72-60-35-83.nip.io/`
+2. Paste your deployer's `0x…` address (EVM format, not a Substrate `5…` address) and click **Send drip**.
+3. You receive **2,000 REEF** within ~30 seconds. The faucet is rate-limited per address and IP; if you need more, ask in the Reef Discord `#dev-support` channel instead of looping drips.
+
+Testnet REEF has no value and cannot be bridged to mainnet.
+
+## 4. Sanity-check the network before deploying
+
+REEF on Pelagia has **12 decimals** (not 18). Confirm both the chain ID and the decimal scaling before anything else:
+
+```bash
+# Chain ID — expect 0x3673 (13939)
+curl -s -X POST -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+  https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/
+
+# Raw balance after one 2,000 REEF drip
+curl -s -X POST -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["<YOUR_ADDRESS>","latest"],"id":1}' \
+  https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/
+```
+
+A 2,000 REEF drip at 12 decimals is `2000 × 10¹² = 0x71afd498d0000`. If you instead see a value around `10²¹`, the RPC layer is scaling to 18 decimals — **stop and report back**, because the app's chain config (`nativeCurrency.decimals`) must match what `eth_getBalance` returns.
+
+## 5. Set up the Hardhat project
+
+```bash
+mkdir fruitful-pelagia-contracts && cd fruitful-pelagia-contracts
+npm init -y
+npm install --save-dev hardhat @parity/hardhat-polkadot@0.1.9
+npx hardhat init   # choose an empty/TypeScript project
+```
+
+`hardhat.config.ts`:
+
+```ts
+import '@parity/hardhat-polkadot';
+
+import type {HardhatUserConfig} from 'hardhat/config';
+
+const config: HardhatUserConfig = {
+	solidity: '0.8.28',
+	resolc: {
+		compilerSource: 'npm'
+	},
+	networks: {
+		pelagia: {
+			polkavm: true,
+			url: process.env.PELAGIA_RPC || 'https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/',
+			chainId: 13939,
+			accounts: [process.env.DEPLOYER_PRIVATE_KEY as string]
+		}
+	}
+};
+
+export default config;
+```
+
+Put `DEPLOYER_PRIVATE_KEY` and `PELAGIA_RPC` in your shell env or a `.env` you never commit.
+
+Notes:
+- The plugin compiles via `resolc` and produces PolkaVM blobs automatically. The code-size limit is 100 KB (vs 24 KB on Ethereum) — both contracts here are far under it.
+- Hardhat Network test helpers (`time`, `loadFixture`) are **not supported** against Pelagia; keep on-chain tests to plain transactions.
+- Exact config keys can drift between plugin versions — if compilation fails, check the plugin README for `@parity/hardhat-polkadot@0.1.9` and the Reef "Hardhat Materials" docs page.
+
+## 6. Add the contracts
+
+### 6a. Multicall3
+
+Copy `Multicall3.sol` verbatim from <https://github.com/mds1/multicall> (MIT licensed, Solidity ≥ 0.8.12) into `contracts/Multicall3.sol`. Do not modify it — the app calls `aggregate3` and `getEthBalance` and expects the standard ABI.
+
+### 6b. Disperse (ported to Solidity 0.8)
+
+The original disperse.app contract is Solidity 0.4.x, which `resolc` cannot compile. Use this port — **function names and signatures must stay exactly as below**, because the app's ABI (`app/_utils/abi/disperse.abi.ts`) is fixed:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}
+
+contract Disperse {
+    function disperseEther(address[] calldata recipients, uint256[] calldata values) external payable {
+        for (uint256 i = 0; i < recipients.length; i++) {
+            (bool success, ) = recipients[i].call{value: values[i]}("");
+            require(success, "Disperse: ETH transfer failed");
+        }
+        uint256 remaining = address(this).balance;
+        if (remaining > 0) {
+            (bool success, ) = msg.sender.call{value: remaining}("");
+            require(success, "Disperse: refund failed");
+        }
+    }
+
+    function disperseToken(IERC20 token, address[] calldata recipients, uint256[] calldata values) external {
+        uint256 total = 0;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            total += values[i];
+        }
+        require(token.transferFrom(msg.sender, address(this), total), "Disperse: transferFrom failed");
+        for (uint256 i = 0; i < recipients.length; i++) {
+            require(token.transfer(recipients[i], values[i]), "Disperse: transfer failed");
+        }
+    }
+
+    function disperseTokenSimple(IERC20 token, address[] calldata recipients, uint256[] calldata values) external {
+        for (uint256 i = 0; i < recipients.length; i++) {
+            require(token.transferFrom(msg.sender, recipients[i], values[i]), "Disperse: transferFrom failed");
+        }
+    }
+}
+```
+
+(The port replaces the original's `transfer()` with `.call{value: …}` — the 2300-gas stipend assumption doesn't hold on PolkaVM.)
+
+## 7. Deploy
+
+`scripts/deploy.ts`:
+
+```ts
+import {ethers} from 'hardhat';
+
+async function main(): Promise<void> {
+	const multicall3 = await ethers.deployContract('Multicall3');
+	await multicall3.waitForDeployment();
+	console.log('Multicall3:', await multicall3.getAddress());
+
+	const disperse = await ethers.deployContract('Disperse');
+	await disperse.waitForDeployment();
+	console.log('Disperse:', await disperse.getAddress());
+}
+
+main().catch(error => {
+	console.error(error);
+	process.exitCode = 1;
+});
+```
+
+```bash
+npx hardhat compile
+npx hardhat run scripts/deploy.ts --network pelagia
+```
+
+Record for each contract: **address, deployment tx hash, and block number** (block number goes into the app config as `blockCreated`). Blocks are ~10s, so confirmation is quick.
+
+## 8. Verify on Blockscout (best-effort)
+
+Open the explorer, find each contract address, and use the "Verify & publish" flow if available. Verification tooling for `resolc`/PolkaVM artifacts is newer than standard solc verification — if the explorer rejects the artifacts, skip verification (the app doesn't depend on it) and note it for later.
+
+## 9. Smoke-test
+
+From the Hardhat console (`npx hardhat console --network pelagia`):
+
+1. **Multicall3**: call `getEthBalance(<your address>)` and check it matches `eth_getBalance`.
+2. **Disperse**: call `disperseEther([addrA, addrB], [v1, v2])` with a small `value: v1 + v2` and confirm both recipients receive funds on the explorer. Remember values are in 12-decimal REEF units — `1 REEF = 10¹²`, so use `ethers.parseUnits('1', 12)`, **not** `parseEther`.
+
+## 10. Hand-off: wire the addresses into the app
+
+In the Fruitful repo, edit the Reef Pelagia entry in `app/_utils/tools.chains.ts`:
+
+- `contracts.multicall3.address` + `blockCreated` → Multicall3 deployment
+- `disperseAddress` → Disperse deployment
+
+And make sure the deployment RPC URL is reflected in `.env` as `RPC_URI_FOR_13939`.
+
+## 11. Expect to do this again
+
+Reef states Pelagia **may be reset on upgrades**, wiping all contracts. Keep this project (with the lockfile) in the Fruitful org so the whole procedure is: faucet → `npx hardhat run scripts/deploy.ts --network pelagia` → update the two config lines.

--- a/docs/pelagia-port-plan.md
+++ b/docs/pelagia-port-plan.md
@@ -1,0 +1,153 @@
+# Plan: Rename Smol → Fruitful and port to Reef Pelagia testnet
+
+This document plans the work to rebrand the Smol dapp suite as **Fruitful** and make it run on **Reef Pelagia**, Reef's next-generation testnet. The companion document [pelagia-contract-deployment.md](./pelagia-contract-deployment.md) is the hand-off guide for whoever deploys the required contracts.
+
+## Reef Pelagia: facts that drive this plan
+
+From the Reef docs (docs.reef.io, retrieved 2026-06-12):
+
+| Parameter | Value |
+| --- | --- |
+| Network name | Reef Pelagia |
+| EVM chain ID | **13939** (note: legacy Reef mainnet/testnet share this ID) |
+| Native token | REEF, **12 decimals** (legacy Reef networks used 18) |
+| HTTP RPC | `https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/` |
+| Block explorer | Blockscout at `https://explorer-frontend-ibcy8d-1204c4-72-60-35-83.nip.io/` |
+| Faucet | `https://faucet.reef-node-reefdevcluster-6058af-72-60-35-83.nip.io/` (2,000 REEF per drip) |
+| Block time | 10s (BABE authoring, GRANDPA finality) |
+| VM | **PolkaVM via `pallet-revive`** — not `pallet-evm` |
+| Native REEF precompile | `0x0000000000000000000000000000000001000000` |
+| Contract code limit | 100 KB blob (vs Ethereum's 24 KB) |
+
+Consequences that matter for this codebase:
+
+- **Contracts must be compiled with `resolc` (Solidity ≥ 0.8.0), not standard `solc`.** No canonical Ethereum contract (Multicall3, Disperse, Safe) exists at its usual address, and deterministic/CREATE2 deployments won't reproduce canonical addresses. Everything we rely on must be deployed fresh and the addresses recorded in our chain config.
+- **viem and ethers v6 are confirmed compatible**, so the wagmi/viem stack survives the port. Hardhat works via `@parity/hardhat-polkadot` v0.1.9; Foundry support is still under evaluation.
+- **12-decimal native currency.** Most of the codebase normalizes by `token.decimals` dynamically, but anything assuming 18 for the gas token must be audited.
+- **Testnet state may be reset on upgrades** — deployments must be reproducible and the addresses easy to swap.
+- The RPC/explorer/faucet hostnames are auto-generated `nip.io` cluster names and differ slightly between doc pages — treat them as unstable and always inject the RPC via env (`RPC_URI_FOR_13939`), never rely on the hardcoded default alone.
+
+---
+
+## Phase 1 — Rename Smol → Fruitful
+
+There are ~167 case-insensitive "smol" occurrences across 63 files in `app/`, plus config and assets. Split into user-visible (must change) and internal (mechanical, optional second pass).
+
+### 1a. Config and metadata (user-visible)
+
+- `package.json` — `"name": "smol"` → `"fruitful"`.
+- `next.config.js`:
+  - `PROJECT_SLUG: 'smoldapp'` → `'fruitful'`.
+  - `WALLETCONNECT_PROJECT_NAME: 'Smol'` → `'Fruitful'`, plus `_DESCRIPTION`, `_URL`, `_ICON` (new domain + icon).
+  - `PLAUSIBLE_DOMAIN: 'smold.app'` and the `withPlausibleProxy` `customDomain` → Fruitful domain (or remove analytics until a domain exists).
+  - The host-based redirects (`multisafe.app`, `migratooor.com`, `disperse.smold.app`, …) are Smol-legacy — drop them.
+  - Decide whether to rename the `SMOL_ASSETS_URL` / `SMOL_ADDRESS` / `SMOL_ADDRESS_V2` env keys (they leak into `app/` code; rename mechanically in one commit if so).
+- `app/manifest.ts` + `app/metadata.ts` + `public/manifest.json` — `siteConfig` name/description/url/ogImage → Fruitful.
+- `README.md` — rewrite (it still describes the even older "Migratooor"; this is the moment to fix it).
+- `CLAUDE.md` — update project description after the rename lands.
+
+### 1b. UI strings and assets (user-visible)
+
+- Branding strings in `app/(apps)/page.tsx`, `app/not-found.tsx`, `app/_components/SideMenu/`, `app/_components/SuccessModal.tsx`, `app/(apps)/pixel/` and the `_appInfo` blurbs.
+- `public/` artwork needs Fruitful replacements: `og.png`, `smol.svg`, `smol-lp.riv` (Rive animation), `smol-swap.mp4`, `avatar.png`, `cover.jpg`, `hero.jpg`, favicons. The `.riv` and `.mp4` need design work — budget for it or remove those sections initially.
+
+### 1c. Internal identifiers (optional second pass)
+
+- `Smol*` component names (`SmolAddressInput`, `SmolTokenSelector`, …), `TSmolChains`, etc. Purely mechanical rename; do it in a dedicated commit with no behavior changes so it's reviewable.
+- Token-list URLs point at `github.com/SmolDapp/tokenLists` (`WithTokenList.tsx:78`, `usePopularTokens.tsx:28`, `Providers.tsx`). These keep working (they're public), but they contain no Pelagia (chain 13939) tokens — see Phase 3. Eventually host a Fruitful token list.
+
+---
+
+## Phase 2 — Add Reef Pelagia to the chain registry
+
+All chain support lives in `app/_utils/tools.chains.ts`. viem has no built-in Pelagia definition, so define it locally:
+
+```ts
+const reefPelagia = defineChain({
+	id: 13939,
+	name: 'Reef Pelagia',
+	nativeCurrency: {name: 'Reef', symbol: 'REEF', decimals: 12},
+	rpcUrls: {
+		default: {http: ['https://eth.reef-node-reefdevcluster-b0be3e-72-60-35-83.nip.io/']}
+	},
+	blockExplorers: {
+		default: {name: 'Reefscout', url: 'https://explorer-frontend-ibcy8d-1204c4-72-60-35-83.nip.io/'}
+	},
+	contracts: {
+		multicall3: {address: '0x…', blockCreated: 0} // ← from the deployment guide
+	},
+	testnet: true
+});
+```
+
+Then the `CHAINS` entry:
+
+```ts
+[reefPelagia.id]: {
+	...reefPelagia,
+	isLifiSwapSupported: false,      // LiFi has no Pelagia support
+	isMultisafeSupported: false,     // no Safe contracts on PolkaVM
+	safeAPIURI: '',
+	safeUIURI: '',
+	coingeckoGasCoinID: 'reef',      // display-only; testnet REEF has no real value
+	llamaChainName: undefined,       // DefiLlama has no Pelagia prices
+	disperseAddress: toAddress('0x…'), // ← from the deployment guide
+	yearnRouterAddress: undefined,
+	rpcUrls: assignRPCUrls(reefPelagia)
+}
+```
+
+Supporting changes:
+
+1. **`next.config.js`**: add `13939: process.env.RPC_URI_FOR_13939` to `RPC_URI_FOR` so the RPC URL is env-overridable (the nip.io default will rot).
+2. **Testnet gating (the big gotcha)**: `useWallet.tsx:103` skips any `chain.testnet` unless `shouldWorkOnTestnet`, and `Providers.tsx` only enables that in dev with `SHOULD_USE_FORKNET`. With `testnet: true`, Pelagia balances would never load in production. Recommended fix: replace the boolean with a per-chain allowlist (or add `isEnabledInProd` to `TSmolChains`) rather than lying about `testnet: false` — `supportedNetworks`/`supportedTestNetworks` filtering in `tools.chains.ts:506` and `WithPrices` both key off that flag.
+3. **Chain-list scope decision**: "port to Pelagia" reads as Pelagia-first. Recommendation: keep **mainnet + Pelagia** in the wagmi config and trim the other ~30 chains from `CHAINS` (or gate them behind a flag). Mainnet must stay because `useENS.ts` (and Clusters lookups) hardcode chain 1 for name resolution; removing it breaks address-book/send name inputs.
+4. **12-decimals audit**: grep for hardcoded 18s touching the *native* token. Known suspects: `tools.erc20.ts:96` (default decimals when a token read fails), `numbers.ts:101` (`zeroNormalizedBN` at 18 — fine as a zero, but verify consumers), `multisafe/components/ChainStatus.tsx:301` (`parseEther` for fees — moot since multisafe is disabled on Pelagia). Everything else flows `token.decimals`/`chain.nativeCurrency.decimals` through viem, which handles 12 correctly.
+5. **Verify, don't trust**: before relying on 12 decimals, drip 2,000 REEF from the faucet and check the raw `eth_getBalance` (expect `2_000 × 10¹²`). `pallet-revive` deployments sometimes re-scale native balances at the EVM RPC layer; the deployment guide includes this check.
+
+---
+
+## Phase 3 — Per-app triage on Pelagia
+
+| App | Status on Pelagia | Work needed |
+| --- | --- | --- |
+| **send** | Works once the chain is registered | Token discovery is empty (no Pelagia tokens in SmolDapp lists); users can paste token addresses. Optionally publish a Fruitful token list for Pelagia test tokens. |
+| **disperse** | Needs the Disperse contract deployed | See deployment guide; set `disperseAddress`. |
+| **wallet** | Needs Multicall3 deployed | `useBalances.multichains.ts:249` falls back to the canonical Multicall3 address, which doesn't exist on Pelagia — the chain's `contracts.multicall3` entry is mandatory, otherwise every balance read reverts. |
+| **swap** | Not portable | LiFi doesn't support Pelagia. `isLifiSwapSupported: false` and hide the nav entry when the active chain is Pelagia. |
+| **multisafe** | Not portable | Safe singleton/proxy-factory don't exist on PolkaVM (and CREATE2-based cross-chain address parity wouldn't hold anyway). `isMultisafeSupported: false`, hide nav entry. |
+| **revoke** | Should work — verify | Relies on `eth_getLogs` range scans (`useInfiniteContractLogs`). Confirm the Pelagia RPC's log-range limits; tune chunk size if needed. |
+| **address-book** | Works | IndexedDB, chain-agnostic. ENS/Clusters resolution keeps using mainnet. |
+| **prices** | Degraded by design | No DefiLlama/yDaemon coverage for Pelagia → token prices show as 0/unknown. Acceptable for a testnet; make sure UI degrades gracefully rather than blocking flows. |
+| **token icons** | Degraded | `SMOL_ASSETS_URL` has no chain-13939 assets; `ImageWithFallback` already handles fallbacks. |
+
+---
+
+## Phase 4 — Contract deployment
+
+Two contracts are required, both small and PolkaVM-compatible once recompiled with `resolc`:
+
+1. **Multicall3** (source: `github.com/mds1/multicall`, Solidity 0.8.12) — for batched balance reads.
+2. **Disperse** — the original disperse.app contract is Solidity 0.4.x and must be ported to ≥ 0.8.0. The ABI consumed by the app (`app/_utils/abi/disperse.abi.ts`: `disperseEther`, `disperseToken`, `disperseTokenSimple`) must be preserved exactly.
+
+The full step-by-step procedure (wallet setup, faucet, Hardhat + `@parity/hardhat-polkadot`, ported Disperse source, verification, hand-off) is in [pelagia-contract-deployment.md](./pelagia-contract-deployment.md).
+
+After deployment, the addresses land in exactly two places in `tools.chains.ts`: `contracts.multicall3` and `disperseAddress` on the Pelagia entry.
+
+---
+
+## Risks and open questions
+
+- **RPC/explorer/faucet URL stability**: nip.io cluster hostnames already differ across doc pages; expect rotation. Mitigation: env-injected RPC, and re-check docs.reef.io before launch.
+- **Testnet resets**: Reef documents that Pelagia state may be reset on upgrades. All deployments must be re-runnable from the guide; the app config must make address swaps a one-line change (it does).
+- **Chain-ID collision**: 13939 is shared with legacy Reef mainnet. Harmless unless both networks are ever configured simultaneously (wagmi keys chains by ID) — never add both.
+- ~~**Native decimals**~~ **Resolved**: confirmed 12-decimal REEF on Pelagia (and on mainnet once the upgrade ships). The on-chain check in the deployment guide remains as a sanity step.
+- **Blockscout verification of resolc artifacts**: contract verification tooling for `pallet-revive` is younger than solc's; the guide treats verification as best-effort with a manual fallback.
+- ~~**PWA/`next-pwa` + analytics**~~ **Resolved**: the app deploys to <https://fruitful.sponsian.org>; manifests, Plausible, and WalletConnect metadata point there.
+
+## Suggested execution order
+
+1. Phase 2 chain registry + testnet gating fix (app runs against Pelagia read-only).
+2. Phase 4 contract deployments (unblocks disperse + wallet balances).
+3. Phase 3 triage: gate swap/multisafe, verify revoke + send end-to-end with faucet REEF.
+4. Phase 1 rename + assets last (or in parallel by a non-engineer for artwork) — it touches the most files and is easiest to review when functional changes are already merged.

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const withPWA = require('next-pwa')({
 
 module.exports = withPlausibleProxy({
 	scriptName: 'script',
-	customDomain: 'https://smold.app'
+	customDomain: 'https://fruitful.sponsian.org'
 })(
 	withPWA({
 		typescript: {
@@ -41,45 +41,7 @@ module.exports = withPlausibleProxy({
 		},
 		transpilePackages: ['lib'],
 		redirects() {
-			return [
-				{source: '/migratooor', destination: '/send', permanent: true},
-				{source: '/safe', destination: '/multisafe', permanent: true},
-				{source: '/stream', destination: 'https://v1.smold.app/stream', permanent: false},
-				{
-					source: '/',
-					has: [{type: 'host', value: 'multisafe.app'}],
-					destination: '/multisafe',
-					permanent: true
-				},
-				{
-					source: '/',
-					has: [{type: 'host', value: 'tokenlistooor.com'}],
-					destination: '/tokenlistooor',
-					permanent: true
-				},
-				{
-					source: '/',
-					has: [{type: 'host', value: 'disperse.smold.app'}],
-					destination: '/disperse',
-					permanent: true
-				},
-				{
-					source: '/',
-					has: [
-						{type: 'host', value: 'nftmigratooor.smold.app'},
-						{type: 'host', value: 'migratooor.com'},
-						{type: 'host', value: 'migrate.smold.app'},
-						{type: 'host', value: 'migratooor.smold.app'}
-					],
-					destination: '/send',
-					permanent: true
-				},
-				{
-					source: '/github',
-					destination: 'https://github.com/SmolDapp/smoldapp',
-					permanent: true
-				}
-			];
+			return [];
 		},
 		async rewrites() {
 			return [
@@ -94,75 +56,38 @@ module.exports = withPlausibleProxy({
 			];
 		},
 		env: {
-			PROJECT_SLUG: 'smoldapp',
+			PROJECT_SLUG: 'fruitful',
 			RPC_URI_FOR: {
 				/**********************************************************************************
-				 ** New RPC Setup for mainnet networks
+				 ** Supported networks: Ethereum mainnet (kept for ENS/Clusters name resolution)
+				 ** and Reef Pelagia testnet. The Pelagia default RPC hostname is an auto-generated
+				 ** cluster name and may rotate — always set RPC_URI_FOR_13939 in production.
 				 *********************************************************************************/
 				1: process.env.RPC_URI_FOR_1,
-				10: process.env.RPC_URI_FOR_10,
-				56: process.env.RPC_URI_FOR_56,
-				100: process.env.RPC_URI_FOR_100,
-				137: process.env.RPC_URI_FOR_137,
-				250: process.env.RPC_URI_FOR_250,
-				252: process.env.RPC_URI_FOR_252,
-				288: process.env.RPC_URI_FOR_288,
-				8453: process.env.RPC_URI_FOR_8453,
-				42161: process.env.RPC_URI_FOR_42161,
-				42170: process.env.RPC_URI_FOR_42170,
-				56288: process.env.RPC_URI_FOR_56288,
-				81457: process.env.RPC_URI_FOR_81457,
-				111188: process.env.RPC_URI_FOR_111188,
-				80094: process.env.RPC_URI_FOR_80094,
-
-				/**********************************************************************************
-				 ** New RPC Setup for testnet networks
-				 *********************************************************************************/
-				97: process.env.RPC_URL_BINANCE_TESTNET,
-				400: process.env.RPC_URL_OPTIMISM_GOERLI,
-				2522: process.env.RPC_URI_FOR_2522,
-				9728: process.env.RPC_URI_FOR_9728,
-				17000: process.env.RPC_URI_FOR_17000,
-				18233: process.env.RPC_URI_FOR_18233,
-				28882: process.env.RPC_URI_FOR_28882,
-				80001: process.env.RPC_URI_FOR_80001,
-				84532: process.env.RPC_URI_FOR_84532,
-				421614: process.env.RPC_URI_FOR_421614,
-				11155111: process.env.RPC_URI_FOR_11155111,
-				11155420: process.env.RPC_URI_FOR_11155420
+				13939: process.env.RPC_URI_FOR_13939
 			},
 			/**********************************************************************************
-			 ** Legacy RPC configuration, mainnet and testnet
+			 ** Legacy RPC configuration, read as a fallback by assignRPCUrls
 			 *********************************************************************************/
 			JSON_RPC_URL: {
-				1: process.env.RPC_URI_FOR_1,
-				10: process.env.RPC_URI_FOR_10,
-				56: process.env.RPC_URI_FOR_56,
-				97: process.env.RPC_URL_FOR_97,
-				137: process.env.RPC_URL_FOR_137,
-				250: process.env.RPC_URL_FOR_250,
-				420: process.env.RPC_URL_FOR_420,
-				8453: process.env.RPC_URL_FOR_8453,
-				80001: process.env.RPC_URL_FOR_80001,
-				42161: process.env.RPC_URL_FOR_42161,
-				11155111: process.env.RPC_URL_FOR_11155111
+				1: process.env.RPC_URI_FOR_1
 			},
 			/**********************************************************************************
 			 ** Wallet Connect configuration
 			 *********************************************************************************/
 			WALLETCONNECT_PROJECT_ID: process.env.WALLETCONNECT_PROJECT_ID,
-			WALLETCONNECT_PROJECT_NAME: 'Smol',
+			WALLETCONNECT_PROJECT_NAME: 'Fruitful',
 			WALLETCONNECT_PROJECT_DESCRIPTION:
 				'Simple, smart and elegant dapps, designed to make your crypto journey a little bit easier.',
-			WALLETCONNECT_PROJECT_URL: 'https://smold.app',
-			WALLETCONNECT_PROJECT_ICON: 'https://smold.app/favicons/ms-icon-310x310.png',
+			WALLETCONNECT_PROJECT_URL: 'https://fruitful.sponsian.org',
+			WALLETCONNECT_PROJECT_ICON: 'https://fruitful.sponsian.org/favicons/ms-icon-310x310.png',
 
 			SHOULD_USE_FORKNET: process.env.SHOULD_USE_FORKNET === 'true',
 
 			SMOL_ASSETS_URL: 'https://assets.smold.app/api',
 			SMOL_ADDRESS: '0x10001192576E8079f12d6695b0948C2F41320040',
 			SMOL_ADDRESS_V2: '0x200010672cDB08a33547fA9C0372f622dfDAEB40',
-			PLAUSIBLE_DOMAIN: 'smold.app'
+			PLAUSIBLE_DOMAIN: 'fruitful.sponsian.org'
 		}
 	})
 );

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "smol",
+	"name": "fruitful",
 	"scripts": {
 		"dev": "next",
 		"dev:ts": "tsc --watch",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,12 +1,11 @@
 {
-	"name": "Smol Dapp",
-	"short_name": "SmolDapp",
+	"name": "Fruitful",
+	"short_name": "Fruitful",
 	"description": "Simple, smart and elegant dapps, designed to make your crypto journey a little bit easier.",
 	"locale": "en-US",
-	"uri": "https://smold.app/",
-	"og": "https://smold.app/og.png",
-	"iconPath": "https://smold.app/favicons/favicon.svg",
-	"twitter": "@smoldapp",
+	"uri": "https://fruitful.sponsian.org/",
+	"og": "https://fruitful.sponsian.org/og.png",
+	"iconPath": "https://fruitful.sponsian.org/favicons/favicon.svg",
 	"icons": [
 		{
 			"src": "./favicons/android-icon-192x192.png",


### PR DESCRIPTION
Rebrand the dapp suite as Fruitful (fruitful.sponsian.org) and retarget it from ~30 EVM chains to Ethereum mainnet + Reef Pelagia (chain 13939, native REEF with 12 decimals, PolkaVM via pallet-revive).

Chain support:
- Rewrite tools.chains.ts to mainnet + a custom Reef Pelagia definition; mainnet is kept for ENS/Clusters resolution and swap/multisafe.
- Add isEnabledInProd so Pelagia is user-facing while still flagged as a testnet; useWallet honors it so balances load in production.
- next.config.js: RPC_URI_FOR_{1,13939}, Fruitful WalletConnect/Plausible metadata, drop legacy smold.app host redirects.

App gating on Pelagia:
- disperse button disabled while disperseAddress is the zero address (multi-recipient path); single-recipient transfer still works.
- swap (LiFi) and multisafe (Safe) already gate to supported chains.
- pixel iframe allowed-origins tightened to Fruitful's domain.

Branding: package name, manifests, metadata, homepage, 404, app-info, tweet-share text, footer GitHub link. Internal Smol* identifiers and SMOL_* env keys left as-is for a later mechanical pass.

Docs: rewrite README; add docs/pelagia-port-plan.md and docs/pelagia-contract-deployment.md; add CLAUDE.md.

Contracts (Multicall3, Disperse) still need deploying on Pelagia; their addresses then go into the Pelagia entry of tools.chains.ts.